### PR TITLE
Added support for >=go1.5

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -21,7 +21,7 @@ func parseRequest(conn io.ReadCloser) (*Request, error) {
 
 	// Multiline request:
 	if line[0] == '*' {
-		if _, err := fmt.Sscanf(line, "*%d\r", &argsCount); err != nil {
+		if _, err := fmt.Sscanf(strings.TrimRight(line, "\n"), "*%d\r", &argsCount); err != nil {
 			return nil, malformed("*<numberOfArguments>", line)
 		}
 		// All next lines are pairs of:
@@ -71,7 +71,7 @@ func readArgument(r *bufio.Reader) ([]byte, error) {
 		return nil, malformed("$<argumentLength>", line)
 	}
 	var argSize int
-	if _, err := fmt.Sscanf(line, "$%d\r", &argSize); err != nil {
+	if _, err := fmt.Sscanf(strings.TrimRight(line, "\n"), "$%d\r", &argSize); err != nil {
 		return nil, malformed("$<argumentSize>", line)
 	}
 

--- a/server.go
+++ b/server.go
@@ -129,7 +129,6 @@ func NewServer(c *Config) (*Server, error) {
 		if method.Name[0] > 'a' && method.Name[0] < 'z' {
 			continue
 		}
-		println(method.Name)
 		handlerFn, err := srv.createHandlerFn(c.handler, &method.Func)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
In go1.5 the Scanf parser was changed WRT to line feeds.

Newer versions of go would fail on every fmt.Sscanf function due to:

golang/go#9459
